### PR TITLE
support for ephemeral storage

### DIFF
--- a/templates/persistentVolumeClaim.yaml
+++ b/templates/persistentVolumeClaim.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.persistence.enabled -}}
 {{ if and (.Values.config.DRONE_DATABASE_DRIVER | default "sqlite3" | eq "sqlite3") (not .Values.persistence.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -15,3 +16,4 @@ spec:
   storageClassName: {{ .Values.persistence.storageClass | quote }}
   {{- end }}
 {{- end }}
+{{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -576,6 +576,7 @@ affinity: {}
 # persistence is only required when config.DATABASE_DRIVER is sqlite3 or
 # undefined.
 persistence:
+  enabled: true
   annotation: {}
   # existingClaim:
   size: 5Gi


### PR DESCRIPTION
added a `enabled` flag to add support for ephemeral storage. 

Use case: in a dev/staging environment, there may not be a need for persistence. 